### PR TITLE
Bugfix and cleanup

### DIFF
--- a/settings.adoc
+++ b/settings.adoc
@@ -12,4 +12,3 @@
 :big-width: width=75%
 :half-width: width=50%
 :icons: font
-

--- a/sources/adversarial-thinking/lifthasir.adoc
+++ b/sources/adversarial-thinking/lifthasir.adoc
@@ -1,6 +1,6 @@
 === Ragnar Lifthrasir - Twitter thread on Adversarial thinking
-****
 
+****
 * Source: https://bitcoinwords.github.io/tweetstorm-on-adversarial-thinking
 * Author: Ragnar Lifthrasir
 * Date copied: 2022-03-07

--- a/sources/adversarial-thinking/loppsecuritymodel.adoc
+++ b/sources/adversarial-thinking/loppsecuritymodel.adoc
@@ -1,6 +1,6 @@
 === Jameson Lopp - Bitcoin’s Security Model: A Deep Dive
-****
 
+****
 * Source: https://blog.lopp.net/bitcoins-security-model-a-deep-dive/
 * Author: Jameson Lopp
 * Date copied: 2022-03-07

--- a/sources/adversarial-thinking/poelstrasecurityassumptions.adoc
+++ b/sources/adversarial-thinking/poelstrasecurityassumptions.adoc
@@ -1,7 +1,6 @@
 === Andrew Poelstra on security assumptions
 
 ****
-
 * Source: https://btctranscripts.com/scalingbitcoin/hong-kong-2015/security-assumptions/
 * Author: Andrew Poelstra, transcribed by Bryan Bishop
 * Date copied: 2022-03-04

--- a/sources/adversarial-thinking/sabotagemanual.adoc
+++ b/sources/adversarial-thinking/sabotagemanual.adoc
@@ -1,7 +1,6 @@
 === Simple Sabotage Field Manual
 
 ****
-
 * Source: https://archive.org/details/SimpleSabotageFieldManualStrategicServicesProvisional
 * Author: Office of Strategic Services, United States
 * Date copied: 2022-03-07

--- a/sources/adversarial-thinking/wikithreats.adoc
+++ b/sources/adversarial-thinking/wikithreats.adoc
@@ -1,6 +1,6 @@
 === Bitcoin Wiki - Weaknesses
-****
 
+****
 * Source: https://en.bitcoin.it/wiki/Weaknesses
 * Author: Various
 * Date copied: 2022-03-07

--- a/sources/common/bitcoinpaper.adoc
+++ b/sources/common/bitcoinpaper.adoc
@@ -1,7 +1,6 @@
 === Bitcoin paper
 
 ****
-
 * Source: https://bitcoin.org/bitcoin.pdf
 * Author: Satoshi Nakamoto
 * Date copied: 2022-03-04

--- a/sources/decentralization/bitcoinmagdecentralization.adoc
+++ b/sources/decentralization/bitcoinmagdecentralization.adoc
@@ -1,4 +1,5 @@
 === The decentralist perspective, or why Bitcoin might need small blocks
+
 ****
 * Source: https://bitcoinmagazine.com/technical/decentralist-perspective-bitcoin-might-need-small-blocks-1442090446
 * Author: Aaron Van Wirdum

--- a/sources/decentralization/irclog20120404.adoc
+++ b/sources/decentralization/irclog20120404.adoc
@@ -1,4 +1,5 @@
 === IRC log 2012-04-04
+
 ****
 * Source: https://gnusha.org/bitcoin-core-dev/bitcoin-dev-2010-2015.txt.xz
 * Author: Wumpus (among others)

--- a/sources/decentralization/maxwellautonomous.adoc
+++ b/sources/decentralization/maxwellautonomous.adoc
@@ -1,7 +1,6 @@
 === Gregory Maxwell on autonomy
 
 ****
-
 * Source: https://www.reddit.com/r/Bitcoin/comments/s82t2n/comment/htdte7w/?utm_source=share&utm_medium=web2x&context=3
 * Author: Gregory Maxwell (nullc)
 * Date copied: 2022-03-04

--- a/sources/decentralization/maxwelldecentralization.adoc
+++ b/sources/decentralization/maxwelldecentralization.adoc
@@ -1,7 +1,6 @@
 === Gregory Maxwell On decetralization
 
 ****
-
 * Source: https://www.reddit.com/r/Bitcoin/comments/ddddfl/question_on_the_vulnerability_of_bitcoin/f2g9e7b/
 * Author: Gregory Maxwell (nullc)
 * Date copied: 2022-03-04

--- a/sources/decentralization/sidechainspaper.adoc
+++ b/sources/decentralization/sidechainspaper.adoc
@@ -1,7 +1,6 @@
 === Paper: Enabling Blockchain Innovations with Pegged Sidechains
 
 ****
-
 * Source: https://www.blockstream.com/sidechains.pdf
 * Author: Adam Back, Matt Corallo, Luke Dashjr, Mark Friedenbach, Gregory Maxwell, Andrew Miller, Andrew Poelstra, Jorge Timón, and Pieter Wuille
 * Date copied: 2022-05-18

--- a/sources/decentralization/ted.adoc
+++ b/sources/decentralization/ted.adoc
@@ -1,7 +1,6 @@
 === Radhika Nagpal on fish schools
 
 ****
-
 * Source: https://www.ted.com/talks/radhika_nagpal_what_intelligent_machines_can_learn_from_a_school_of_fish
 * Author: Radhika Nagpal
 * Date copied: 2022-03-04

--- a/sources/decentralization/wuillese.adoc
+++ b/sources/decentralization/wuillese.adoc
@@ -1,7 +1,6 @@
 === Pieter Wuille On neutrality
 
 ****
-
 * Source: https://bitcoin.stackexchange.com/a/92055/69518
 * Author: Pieter Wuille
 * Date copied: 2022-03-04

--- a/sources/finite-supply/chytriktrustsupply.adoc
+++ b/sources/finite-supply/chytriktrustsupply.adoc
@@ -1,12 +1,10 @@
 === chytrik - How can we trust supply won't be increased in 2140 by just a few lines of code?
-****
 
+****
 * Source: https://bitcoin.stackexchange.com/a/106830/69518
 * Author: User chytrik on Bitcoin Stack Exchange
 * Date copied: 2022-03-07
 ****
-
-
 
 The bitcoin network is composed of 'bitcoin full nodes', which are computers located all around the world, each one running independently to verify the state of the network.
 

--- a/sources/finite-supply/wuillesupply.adoc
+++ b/sources/finite-supply/wuillesupply.adoc
@@ -1,6 +1,6 @@
 === Pieter Wuille - Will there be 21 million bitcoins eventually?
-****
 
+****
 * Source: https://bitcoin.stackexchange.com/a/38998/69518
 * Author: Pieter Wuille
 * Date copied: 2022-03-07

--- a/sources/privacy/belcherprivacy.adoc
+++ b/sources/privacy/belcherprivacy.adoc
@@ -1,7 +1,6 @@
 === Chris Belcher - Bitcoin wiki page on Privacy
 
 ****
-
 * Source: https://en.bitcoin.it/Privacy
 * Author: Chris Belcher (and others)
 * Date copied: 2022-03-07

--- a/sources/privacy/maxwellprivacy.adoc
+++ b/sources/privacy/maxwellprivacy.adoc
@@ -1,7 +1,6 @@
 === Gregory Maxwell - on privacy
 
 ****
-
 * Source: https://bitcointalk.org/index.php?topic=334316.msg3588908#msg3588908
 * Author: Gregory Maxwell
 * Date copied: 2022-03-07

--- a/sources/privacy/maxwellwhitehat.adoc
+++ b/sources/privacy/maxwellwhitehat.adoc
@@ -1,6 +1,6 @@
 === Gregory Maxwell - Bad privacy contagious
-****
 
+****
 * Source: https://bitcointalk.org/index.php?topic=334316.msg3589252#msg3589252
 * Author: Gregory Maxwell
 * Date copied: 2022-03-07

--- a/sources/trustlessness/corallotrustless.adoc
+++ b/sources/trustlessness/corallotrustless.adoc
@@ -1,7 +1,6 @@
 === Corallo on trustlessness
 
 ****
-
 * Source: https://btctranscripts.com/baltic-honeybadger/2018/trustlessness-scalability-and-directions-in-security-models/
 * Author: Matt Corallo, transcribed by Bryan Bishop
 * Date copied: 2022-03-04

--- a/sources/trustlessness/cve-2018-17144.adoc
+++ b/sources/trustlessness/cve-2018-17144.adoc
@@ -1,7 +1,6 @@
 === CVE-2018-17144 Full Disclosure
 
 ****
-
 * Source: https://bitcoincore.org/en/2018/09/20/notice/
 * Author: Bitcoin Core team
 * Date copied: 2022-03-04

--- a/sources/trustlessness/wuilletrustless.adoc
+++ b/sources/trustlessness/wuilletrustless.adoc
@@ -1,7 +1,6 @@
 === Pieter Wuille on trustlessness
 
 ****
-
 * Source: https://bitcoin.stackexchange.com/questions/45670/can-a-closed-source-wallet-ever-be-completely-trust-less/45674#45674
 * Author: Pieter Wuille
 * Date copied: 2022-03-04


### PR DESCRIPTION
* Make sources' headers more consistent
* Bugfix: if there's an empty line at the end of settings.adoc, you can't include that file an add/override settings in the including file.