### PR TITLE
More space after quotes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ B=build
 ALLPNGS := $(patsubst %,$(B)/%,$(wildcard images/*.png))
 ALLJPGS := $(patsubst %,$(B)/%,$(wildcard images/*.jpg))
 ALLIMGS := $(ALLPNGS) $(ALLJPGS)
+STYLE := $(patsubst %,$(B)/%,$(wildcard style/*))
 BOOKHTML=$(B)/$(BASE_NAME).html
 SOURCES := sources
 SOURCESIMAGES := $(patsubst %,$(B)/%,$(wildcard $(SOURCES)/images/*))
@@ -17,7 +18,7 @@ IMEXISTS := $(shell convert -version 2> /dev/null)
 .PHONY: all
 all: full
 
-full: $(B) $(BOOKHTML) $(SOURCESHTML)
+full: $(B) $(STYLE) $(BOOKHTML) $(SOURCESHTML)
 
 $(BOOKHTML): $(ALLADOC) $(ALLPNGS) $(ALLJPGS)
 	$(AD) $(MAINADOC) -o $@
@@ -42,14 +43,16 @@ else
 	convert $< -resize 1024x1024\> $@
 endif
 
+$(STYLE): $(B)/%: %
+	cp $< $@
 
 $(B):
-	@mkdir -p $(B)
-	@mkdir -p $(B)/images
-	cp -fr style $(B)
-	@mkdir -p $(B)/$(SOURCES)
-	@mkdir -p $(B)/$(SOURCES)/images
-	cp -fr $(SOURCES)/style $(B)/$(SOURCES)
+	@mkdir $(B)
+	@mkdir $(B)/images
+	@mkdir $(B)/style
+	@mkdir $(B)/$(SOURCES)
+	@mkdir $(B)/$(SOURCES)/images
+	@mkdir $(B)/$(SOURCES)/style
 
 clean:
 	rm -rf $(B)

--- a/style/btcphilosophy.css
+++ b/style/btcphilosophy.css
@@ -8,6 +8,10 @@ body {
     width: 50%
 }
 
+.quoteblock {
+    margin-bottom: 2em;
+}
+
 /* .quote and .code are to make quotes in passthrough html from bitcointalk.org 
    look ok. See comment in sources/finite-supply/nakamotolostcoins.adoc   
  */


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/1530071/215320218-98ea3a74-2882-4c01-abb4-43edd1b880ad.png)

After:

![image](https://user-images.githubusercontent.com/1530071/215320259-c220ee77-f276-47a8-a190-00e51dfcd486.png)

If you want to play around with this, you can change the value of `margin-bottom` under the `.quoteblock` section in `style/btcphilosophy.css`. I changed it from the default 1.25em (I think) to 2em.