### PR TITLE
Qrcodes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,14 @@
-AD=asciidoctor -b html5 -v
-ADPDF=asciidoctor-pdf
+AD=asciidoctor -b html5 -v -r asciidoctor-diagram
+ADPDF=asciidoctor-pdf -r asciidoctor-diagram
 BASE_NAME=btcphilosophy
-MAINADOC=$(BASE_NAME).adoc
 B=build
+MAINADOC=$(B)/$(BASE_NAME).adoc
 ALLADOC := $(patsubst %,$(B)/%,$(wildcard *.adoc))
 ALLPNGS := $(patsubst %,$(B)/%,$(wildcard images/*.png))
 ALLJPGS := $(patsubst %,$(B)/%,$(wildcard images/*.jpg))
 ALLIMGS := $(ALLPNGS) $(ALLJPGS)
 CSS := $(B)/style/btcphilosophy.css
+DOCINFO := $(B)/style/docinfo.html
 BOOKHTML=$(B)/$(BASE_NAME).html
 BOOKPDF=$(B)/$(BASE_NAME).pdf
 SOURCES := sources
@@ -15,7 +16,9 @@ SOURCESIMAGES := $(patsubst %,$(B)/%,$(wildcard $(SOURCES)/images/*))
 MAINSOURCESADOC := $(SOURCES)/sources.adoc
 ALLSOURCESADOC := $(MAINSOURCESADOC) $(wildcard $(SOURCES)/**/*.adoc)
 SOURCESCSS := $(B)/sources/style/btcphilosophy.css
+SOURCESDOCINFO := $(B)/sources/style/docinfo.html
 SOURCESHTML=$(B)/$(SOURCES)/sources.html
+
 IMEXISTS := $(shell command -v convert 2> /dev/null)
 ADPDFEXISTS := $(shell $(ADPDF) --version 2> /dev/null)
 
@@ -33,11 +36,10 @@ endif
 
 full: $(B) $(BOOKHTML) $(SOURCESHTML)
 
-$(BOOKHTML): $(CSS) $(ALLADOC) $(ALLPNGS) $(ALLJPGS)
+$(BOOKHTML): $(CSS) $(DOCINFO) $(ALLADOC) $(ALLPNGS) $(ALLJPGS)
 	$(AD) $(MAINADOC) -o $@
 
-$(SOURCESHTML): $(SOURCESCSS) $(ALLSOURCESADOC) $(SOURCESIMAGES)
-	mkdir -p $(B)/sources
+$(SOURCESHTML): $(SOURCESCSS) $(SOURCESDOCINFO) $(ALLSOURCESADOC) $(SOURCESIMAGES)
 	$(AD) $(MAINSOURCESADOC) -o $@
 
 $(SOURCESIMAGES): $(B)/%: %
@@ -46,6 +48,9 @@ $(SOURCESIMAGES): $(B)/%: %
 # and there are many formats to make special cases for (mp4, pdf)
 # Maybe we'll change this at some point.
 	cp $< $@
+
+$(ALLADOC): $(B)/%: %
+	cat $< | notes/qrcodes.sh > $@
 
 $(ALLIMGS): $(B)/%: %
 	mkdir -p $(dir $@)
@@ -56,7 +61,7 @@ else
 	convert $< -resize 1024x1024\> $@
 endif
 
-$(CSS) $(SOURCESCSS) $(ALLADOC): $(B)/%: %
+$(CSS) $(SOURCESCSS) $(DOCINFO) $(SOURCESDOCINFO) $(ALLADOC): $(B)/%: %
 	@mkdir -p $(dir $@)
 	cp $< $@
 

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ else
 	convert $< -resize 1024x1024\> $@
 endif
 
-$(CSS) $(SOURCESCSS) $(DOCINFO) $(SOURCESDOCINFO) $(ALLADOC): $(B)/%: %
+$(CSS) $(SOURCESCSS) $(DOCINFO) $(SOURCESDOCINFO): $(B)/%: %
 	@mkdir -p $(dir $@)
 	cp $< $@
 

--- a/build.adoc
+++ b/build.adoc
@@ -16,6 +16,16 @@ There's also a separate asciidoctor file, link:sources/sources.adoc[],
 that collects all the copied resources that the book refers to. They
 are kept separate to not make browsing the book itself too heavy.
 
+Before you build, you need to install some dependencies:
+
+* `asciidoctor`, See
+  https://docs.asciidoctor.org/asciidoctor/latest/install/[installation
+  instructions]
+* The `asciidoctor-diagram` extension to `asciidoctor`. See
+  https://docs.asciidoctor.org/diagram-extension/latest/#installation[installation
+  instructions]
+* Gnu `make`
+
 To build this book, clone the GitHub repository:
 
 ----
@@ -25,11 +35,12 @@ $ cd btcphilosophy
 
 and then build using any of the two methods below
 
-==== Using `asciidoctor`
+==== Manually using `asciidoctor`
 
 Use this option if you just want to casually build the book and read
 the end result locally. It requires only `asciidoctor` to be present
-on your computer.
+on your computer. This method won't give you QR codes to links in the
+margin.
 
 ----
 $ asciidoctor -v btcphilosophy.adoc
@@ -71,9 +82,9 @@ images for faster download over the web. Otherwise it'll write a
 warning message saying that the images will not be resized.
 
 This method of building is usually preferred as it keeps the source
-tree separate from ascriidoctor output files, and it will reduce the
+tree separate from ascriidoctor output files, reduces the
 size of pictures to make it more appropriate for serving the book
-on the web.
+on the web, and produces QR codes in the margin for the links.
 
 ==== Build a PDF
 

--- a/finite-supply.adoc
+++ b/finite-supply.adoc
@@ -34,6 +34,7 @@ ____
 This leaves us with *20999817.31308491* BTC (taking everything up to
 block 528333 into account)
 
+//noqr
 \... However, various wallets have been lost or stolen, transactions
 have been sent to the wrong address, people forgot they owned
 bitcoin. The totals of this may well be millions. People have tried to
@@ -123,6 +124,7 @@ extending it. Bitcoin Optech has a specific
 https://bitcoinops.org/en/topics/fee-sniping/[section on this
 behavior], called _fee sniping_, written by David Harding:
 
+//noqr
 [quote,"David Harding, fee sniping", Bitcoin Optech website]
 ____
 Fee sniping is a problem that may occur as Bitcoin’s subsidy continues

--- a/notes/qrcodes.sh
+++ b/notes/qrcodes.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+URLPREFIX=https://example.com/
+
+function printblock() {
+    if [[ "$1" =~ ^//noqr.* ]]; then
+	echo -e "$1"
+	return
+    fi
+
+    urls=$(echo "$1" | grep -o 'https\?://[^[:space:][]\+')
+
+    # if there are URLs in the block, print them and the block itself
+    for url in $urls
+    do
+	hash=`echo -e "$url" | sha256sum`
+	path=${hash:0:8}
+	shorturl=${URLPREFIX}${path}
+        echo -e "[qrcode,role=qrcode]"
+        echo -e "----"
+        echo -e "${shorturl}"
+        echo -e "----\n"
+    done
+    echo -e "$1"
+}
+
+
+read -r block    # First line only
+block+='\n'
+while read -r; do
+    if [[ $REPLY =~ ^$ ]]; then
+        # Do what you like with the contents
+        # $block here, then ...
+        printblock "$block"
+        block=""
+    else
+        block+="$REPLY\n"
+    fi
+done
+printblock "$block"

--- a/notes/qrcodes.sh
+++ b/notes/qrcodes.sh
@@ -2,26 +2,31 @@
 
 URLPREFIX=https://example.com/
 
+function shorten() {
+  hash=`echo -e "$1" | sha256sum`
+  path=${hash:0:8}
+  shorturl=${URLPREFIX}${path}
+  echo "${shorturl}"
+}
+
 function printblock() {
-    if [[ "$1" =~ ^//noqr.* ]]; then
-	echo -e "$1"
-	return
-    fi
-
-    urls=$(echo "$1" | grep -o 'https\?://[^[:space:][]\+')
-
-    # if there are URLs in the block, print them and the block itself
-    for url in $urls
-    do
-	hash=`echo -e "$url" | sha256sum`
-	path=${hash:0:8}
-	shorturl=${URLPREFIX}${path}
-        echo -e "[qrcode,role=qrcode]"
-        echo -e "----"
-        echo -e "${shorturl}"
-        echo -e "----\n"
-    done
+  if [[ "$1" =~ ^//noqr.* ]]; then
     echo -e "$1"
+	  return
+  fi
+
+  urls=$(echo "$1" | grep -o 'https\?://[^[]\+\[')
+
+  # if there are URLs in the block, print them and the block itself
+  for url in $urls
+  do
+    shorturl=`shorten "$url"`
+    echo -e "[qrcode,role=qrcode]"
+    echo -e "----"
+    echo -e "${shorturl}"
+    echo -e "----\n"
+  done
+  echo -e "$1"
 }
 
 

--- a/open-source.adoc
+++ b/open-source.adoc
@@ -295,6 +295,7 @@ Below is a distilled version of that list:
 While this is not the ultimate guide to success, it can be very helpful
 to go through these points when doing selection cryptography.
 
+//noqr
 Due to the issues mentioned above by Maxwell, Bitcoin Core tries
 really hard to
 https://github.com/bitcoin/bitcoin/blob/master/doc/dependencies.md[minimize its exposure to third party libraries]. Of course, you can't

--- a/open-source.adoc
+++ b/open-source.adoc
@@ -16,7 +16,7 @@ Most Bitcoin softwares, and especially Bitcoin Core, is open
 source. This means that the source code of the software is made
 available to the general public for scrutiny, tinkering, modification,
 and redistribution. The definition of open source at
-https://opensource.org/osd includes, among others, the following
+https://opensource.org/osd[] includes, among others, the following
 important points:
 
 [quote, The Open Source Definition, Open Source Initiative website]
@@ -147,6 +147,7 @@ to develop systems on top of Bitcoin, without asking for any
 permission. We've seen countless successful software projects that were
 built on top of Bitcoin, such as:
 
+//noqr
 Lightning Network:: A payment network that allows for fast payment of
 very small amounts. It requires very few on-chain Bitcoin
 transactions. Various inter-operable implementations exist, such as

--- a/privacy.adoc
+++ b/privacy.adoc
@@ -302,9 +302,10 @@ leaks. Among the most obvious ones is, as
 noted by Nakamoto>> in <<blockchainprivacy>>, using unique
 addresses for every transaction, but several others exist. We're not
 going to teach you how to become a privacy ninja. However, Bitcoin Q+A has
-a quick summary of privacy-enhancing technologies, somewhat ordered by
-how hard they are to implement, at
-https://bitcoiner.guide/privacytips/. When you read it, you'll notice
+a https://bitcoiner.guide/privacytips/[quick summary of
+privacy-enhancing technologies], somewhat ordered by
+how hard they are to implement.
+When you read it, you'll notice
 that Bitcoin privacy often has to do with stuff outside of Bitcoin.
 For example, you shouldn't brag about your bitcoins, and you should use Tor and VPN. The
 post also lists some measures directly related to Bitcoin:
@@ -383,6 +384,7 @@ party. Unfortunately some sell other coins as well as bitcoin so we
 urge you to take care.
 ____
 
+//noqr
 The article suggests you avoid using exchanges that require KYC/AML
 and instead trade in private, or use decentralized exchanges like
 https://bisq.network/[bisq].

--- a/privacy.adoc
+++ b/privacy.adoc
@@ -215,6 +215,7 @@ internet connections are involved, the adversary will be able to link
 the IP address with the discovered bitcoin information.
 ____
 
+//noqr
 [[kycdbs]]
 However, among the most obvious privacy leaks are exchanges. Due to
 laws, usually referred to as KYC (Know Your Customer) and AML

--- a/scaling.adoc
+++ b/scaling.adoc
@@ -242,7 +242,7 @@ https://blog.lopp.net/bitcoin-core-performance-evolution/[has run
 benchmark tests] on blockchain synchronization, comparing many
 different versions of Bitcoin Core going back to version 0.8.
 
-.Initial block download performance of various versions of Bitcoin Core. On the Y-axis is the block height synced and on the X-axis is the time it took to sync to that height. Source: https://blog.lopp.net/bitcoin-core-performance-evolution/
+.Initial block download performance of various versions of Bitcoin Core. On the Y-axis is the block height synced and on the X-axis is the time it took to sync to that height.
 image::Bitcoin-Core-Sync-Performance-1.png[{big-width}]
 
 The different lines represent different versions of Bitcoin Core. The
@@ -265,7 +265,7 @@ https://twitter.com/pwuille/status/1450471673321381896[Twitter
 thread] showcasing the performance improvements achieved through various pull
 requests.
 
-.Performance of signature verification over time, with significant pull requests marked on the timeline. Source: https://twitter.com/pwuille/status/1450471673321381896
+.Performance of signature verification over time, with significant pull requests marked on the timeline.
 image::libsecp256k1speedups.png[{half-width}]
 
 The graph shows the trend for two different 64-bit CPU types, namely ARM and x86.

--- a/style/btcphilosophy.css
+++ b/style/btcphilosophy.css
@@ -22,6 +22,7 @@ body {
     margin: 1px;
     padding: 1px;
 }
+
 .code
 {
     font-size: x-small;
@@ -29,4 +30,9 @@ body {
     border: 1px solid black;
     margin: 1px;
     padding: 1px;
+}
+
+.qrcode
+{
+    float: right;
 }

--- a/style/pdf-theme.yml
+++ b/style/pdf-theme.yml
@@ -1,3 +1,7 @@
 extends: default
 # Add stuff here. See https://docs.asciidoctor.org/pdf-converter/latest/theme/
 # for details.
+#role:
+#  qr:
+#    align: right
+#image:

--- a/trustlessness.adoc
+++ b/trustlessness.adoc
@@ -214,6 +214,7 @@ ____
 Don't trust, verify.
 ____
 
+//noqr
 This alludes to the phrase
 "https://en.wikipedia.org/wiki/Trust,_but_verify[trust, but verify]"
 that former U.S. president Ronald Reagan used in the context of

--- a/upgrading.adoc
+++ b/upgrading.adoc
@@ -302,6 +302,7 @@ them on the Bitcoin Wiki]. In his article he explained some properties
 of BIP8, which at that time had some recent changes made in order to make it
 more flexible.
 
+//noqr
 [quote, David Harding, Taproot Activation Proposals on the Bitcoin Wiki (2020)]
 ____
 At the time this document is being written,
@@ -313,6 +314,7 @@ forced activation is a boolean parameter chosen when a soft fork’s
 activation parameters are set either for the initial deployment or
 updated in a later deployment.
 
+//noqr
 BIP8 without forced activation is very similar to
 https://github.com/bitcoin/bips/blob/master/bip-0009.mediawiki[BIP9]
 version bits with timeout and delay, with the only significant
@@ -398,6 +400,7 @@ end the debate (for now, if activation is successful) or give us some
 actual data upon which to base future taproot activation proposals.
 ____
 
+//noqr
 This deployment mechanism was refined over the course of two months
 and then released in
 https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-0.21.1.md#taproot-soft-fork[Bitcoin

--- a/upgrading.adoc
+++ b/upgrading.adoc
@@ -18,7 +18,7 @@ ____
 Bitcoin experts talk often of consensus, whose meaning is abstract and
 hard to pin down. But the word consensus evolved from the Latin word
 concentus, "a singing together,
-harmony,"[https://bitcointalk.org/dec/p1.html#ftnt1[1]] so let us talk
+harmony,"[1] so let us talk
 not of Bitcoin consensus but of Bitcoin harmony.
 
 Harmony is what makes Bitcoin work. Thousands of full nodes each work
@@ -88,6 +88,7 @@ about Bitcoin's different upgrading mechanisms, pointing out how much they
 have evolved over time. He even explained how Satoshi Nakamoto
 once upgraded Bitcoin through a hard fork.
 
+//noqr
 [quote, Eric Lombrozo, Changing Consensus Rules Without Breaking Bitcoin at Breaking Bitcoin conference (2017)]
 ____
 There was actually a hard-fork in bitcoin that Satoshi did that we

--- a/when-shit-hits-the-fan.adoc
+++ b/when-shit-hits-the-fan.adoc
@@ -387,6 +387,7 @@ the files blkXXXX.dat and blkindex.dat. The reason for downloading the
 blockchain data this way, as opposed to synchronizing from scratch, was
 to reduce network bandwidth bottlenecks.
 
+//noqr
 There was a big caveat with this: the data users would download from
 knightmb https://bitcoin.stackexchange.com/a/113682/69518[weren't
 verified by the Bitcoin software] at startup. The blkindex.dat file
@@ -394,6 +395,7 @@ contained the UTXO set, and the software would accept any data therein
 as if it had already verified it. knightmb could have manipulated the
 data to give himself or anyone else some bitcoins.
 
+//noqr
 Again, people seemed to go along with this, and the reversal of the
 invalid block and its successors was successful. Miners started
 working on a new successor to block
@@ -669,6 +671,7 @@ ____
 The alert page instructed people to wait for 30 additional confirmations
 than they normally would in case they were using older versions of Bitcoin Core.
 
+//noqr
 The split mentioned above occurred on 2015-07-04 at 02:10 UTC after block
 height
 https://mempool.space/block/000000000000000006a320d752b46b532ec0f3f815c5dae467aff5715a6e579e[363730]. This


### PR DESCRIPTION
This PR adds a QR code to the right of paragraphs containing external links, so that readers easily can visit the discussed links on their phone. Right now, the QR codes are displayed both on html and pdf versions, and both on paper and on screen.

We might be able to tweak this to only show on the PDF version, or more advanced, only in paper book. I haven't investigated what's possible on that front, but for now I think we can have the QR codes in all book formats.

A few kinks/questions

* The script that inserts the QR code is ~~HORRIBLE~~ ~~TERRIBLE~~ DISGUSTING, see [Makefile](https://github.com/bitcoin-dev-philosophy/btcphilosophy/blob/c474159dc2bbb7a85a62ee6c2a77bbca94380415/Makefile#L50). If anyone has a better way to do it, please let me know, or offer a PR for it.
* The QRs show the full URL. It might be a good idea to use short-URLs, because the QRs become smaller but also of equal size. The downside is that we need to maintain the short-URLs on some webserver or use a 3rd-party service.
* The QRs are currently "float right" which means that the QR is placed to the right of the paragraph, and text floats around it. It might be better to put them completely in the margin.

What do y'all think?


Example: 
![image](https://user-images.githubusercontent.com/1530071/227739054-7770df91-f251-41e4-9e9a-853e359c4ae9.png)

